### PR TITLE
Fix raw socket flags

### DIFF
--- a/include/tcp.hrl
+++ b/include/tcp.hrl
@@ -36,12 +36,14 @@
         active]).
 
 -define(DARWIN_SOL_SOCKET, 16#ffff).
+-define(DARWIN_IPPROTO_TCP, 16#0006).
 -define(DARWIN_SO_KEEPALIVE, 16#0008).
 -define(DARWIN_TCP_KEEPIDLE, 16#10). % idle time used when SO_KEEPALIVE is enabled
 -define(DARWIN_TCP_KEEPINTVL, 16#101). % interval between keepalives
 -define(DARWIN_TCP_KEEPCNT, 16#102). % number of keepalives before close
 
 -define(LINUX_SOL_SOCKET, 16#0001).
+-define(LINUX_SOL_TCP, 16#0006).
 -define(LINUX_SO_KEEPALIVE, 16#0009).
 -define(LINUX_TCP_KEEPIDLE, 16#4). % idle time used when SO_KEEPALIVE is enabled
 -define(LINUX_TCP_KEEPINTVL, 16#5). % interval between keepalives

--- a/include/tcp.hrl
+++ b/include/tcp.hrl
@@ -38,7 +38,7 @@
 -define(DARWIN_SOL_SOCKET, 16#ffff).
 -define(DARWIN_IPPROTO_TCP, 16#0006).
 -define(DARWIN_SO_KEEPALIVE, 16#0008).
--define(DARWIN_TCP_KEEPIDLE, 16#10). % idle time used when SO_KEEPALIVE is enabled
+-define(DARWIN_TCP_KEEPALIVE, 16#10). % idle time used when SO_KEEPALIVE is enabled
 -define(DARWIN_TCP_KEEPINTVL, 16#101). % interval between keepalives
 -define(DARWIN_TCP_KEEPCNT, 16#102). % number of keepalives before close
 

--- a/src/driver/gen_rpc_driver_ssl.erl
+++ b/src/driver/gen_rpc_driver_ssl.erl
@@ -235,9 +235,9 @@ set_socket_keepalive({unix, darwin}, Socket) ->
     {ok, KeepInterval} = application:get_env(?APP, socket_keepalive_interval),
     {ok, KeepCount} = application:get_env(?APP, socket_keepalive_count),
     ok = ssl:setopts(Socket, [{raw, ?DARWIN_SOL_SOCKET, ?DARWIN_SO_KEEPALIVE, <<1:32/native>>}]),
-    ok = ssl:setopts(Socket, [{raw, ?DARWIN_SOL_SOCKET, ?DARWIN_TCP_KEEPIDLE, <<KeepIdle:32/native>>}]),
-    ok = ssl:setopts(Socket, [{raw, ?DARWIN_SOL_SOCKET, ?DARWIN_TCP_KEEPINTVL, <<KeepInterval:32/native>>}]),
-    ok = ssl:setopts(Socket, [{raw, ?DARWIN_SOL_SOCKET, ?DARWIN_TCP_KEEPCNT, <<KeepCount:32/native>>}]),
+    ok = ssl:setopts(Socket, [{raw, ?DARWIN_IPPROTO_TCP, ?DARWIN_TCP_KEEPALIVE, <<KeepIdle:32/native>>}]),
+    ok = ssl:setopts(Socket, [{raw, ?DARWIN_IPPROTO_TCP, ?DARWIN_TCP_KEEPINTVL, <<KeepInterval:32/native>>}]),
+    ok = ssl:setopts(Socket, [{raw, ?DARWIN_IPPROTO_TCP, ?DARWIN_TCP_KEEPCNT, <<KeepCount:32/native>>}]),
     ok;
 
 set_socket_keepalive({unix, linux}, Socket) ->
@@ -245,9 +245,9 @@ set_socket_keepalive({unix, linux}, Socket) ->
     {ok, KeepInterval} = application:get_env(?APP, socket_keepalive_interval),
     {ok, KeepCount} = application:get_env(?APP, socket_keepalive_count),
     ok = ssl:setopts(Socket, [{raw, ?LINUX_SOL_SOCKET, ?LINUX_SO_KEEPALIVE, <<1:32/native>>}]),
-    ok = ssl:setopts(Socket, [{raw, ?LINUX_SOL_SOCKET, ?LINUX_TCP_KEEPIDLE, <<KeepIdle:32/native>>}]),
-    ok = ssl:setopts(Socket, [{raw, ?LINUX_SOL_SOCKET, ?LINUX_TCP_KEEPINTVL, <<KeepInterval:32/native>>}]),
-    ok = ssl:setopts(Socket, [{raw, ?LINUX_SOL_SOCKET, ?LINUX_TCP_KEEPCNT, <<KeepCount:32/native>>}]),
+    ok = ssl:setopts(Socket, [{raw, ?LINUX_SOL_TCP, ?LINUX_TCP_KEEPIDLE, <<KeepIdle:32/native>>}]),
+    ok = ssl:setopts(Socket, [{raw, ?LINUX_SOL_TCP, ?LINUX_TCP_KEEPINTVL, <<KeepInterval:32/native>>}]),
+    ok = ssl:setopts(Socket, [{raw, ?LINUX_SOL_TCP, ?LINUX_TCP_KEEPCNT, <<KeepCount:32/native>>}]),
     ok;
 
 set_socket_keepalive(_Unsupported, _Socket) ->

--- a/src/driver/gen_rpc_driver_tcp.erl
+++ b/src/driver/gen_rpc_driver_tcp.erl
@@ -210,9 +210,9 @@ set_socket_keepalive({unix, darwin}, Socket) ->
     {ok, KeepInterval} = application:get_env(?APP, socket_keepalive_interval),
     {ok, KeepCount} = application:get_env(?APP, socket_keepalive_count),
     ok = inet:setopts(Socket, [{raw, ?DARWIN_SOL_SOCKET, ?DARWIN_SO_KEEPALIVE, <<1:32/native>>}]),
-    ok = inet:setopts(Socket, [{raw, ?DARWIN_SOL_SOCKET, ?DARWIN_TCP_KEEPIDLE, <<KeepIdle:32/native>>}]),
-    ok = inet:setopts(Socket, [{raw, ?DARWIN_SOL_SOCKET, ?DARWIN_TCP_KEEPINTVL, <<KeepInterval:32/native>>}]),
-    ok = inet:setopts(Socket, [{raw, ?DARWIN_SOL_SOCKET, ?DARWIN_TCP_KEEPCNT, <<KeepCount:32/native>>}]),
+    ok = inet:setopts(Socket, [{raw, ?DARWIN_IPPROTO_TCP, ?DARWIN_TCP_KEEPIDLE, <<KeepIdle:32/native>>}]),
+    ok = inet:setopts(Socket, [{raw, ?DARWIN_IPPROTO_TCP, ?DARWIN_TCP_KEEPINTVL, <<KeepInterval:32/native>>}]),
+    ok = inet:setopts(Socket, [{raw, ?DARWIN_IPPROTO_TCP, ?DARWIN_TCP_KEEPCNT, <<KeepCount:32/native>>}]),
     ok;
 
 set_socket_keepalive({unix, linux}, Socket) ->
@@ -220,9 +220,9 @@ set_socket_keepalive({unix, linux}, Socket) ->
     {ok, KeepInterval} = application:get_env(?APP, socket_keepalive_interval),
     {ok, KeepCount} = application:get_env(?APP, socket_keepalive_count),
     ok = inet:setopts(Socket, [{raw, ?LINUX_SOL_SOCKET, ?LINUX_SO_KEEPALIVE, <<1:32/native>>}]),
-    ok = inet:setopts(Socket, [{raw, ?LINUX_SOL_SOCKET, ?LINUX_TCP_KEEPIDLE, <<KeepIdle:32/native>>}]),
-    ok = inet:setopts(Socket, [{raw, ?LINUX_SOL_SOCKET, ?LINUX_TCP_KEEPINTVL, <<KeepInterval:32/native>>}]),
-    ok = inet:setopts(Socket, [{raw, ?LINUX_SOL_SOCKET, ?LINUX_TCP_KEEPCNT, <<KeepCount:32/native>>}]),
+    ok = inet:setopts(Socket, [{raw, ?LINUX_SOL_TCP, ?LINUX_TCP_KEEPIDLE, <<KeepIdle:32/native>>}]),
+    ok = inet:setopts(Socket, [{raw, ?LINUX_SOL_TCP, ?LINUX_TCP_KEEPINTVL, <<KeepInterval:32/native>>}]),
+    ok = inet:setopts(Socket, [{raw, ?LINUX_SOL_TCP, ?LINUX_TCP_KEEPCNT, <<KeepCount:32/native>>}]),
     ok;
 
 set_socket_keepalive(_Unsupported, _Socket) ->

--- a/src/driver/gen_rpc_driver_tcp.erl
+++ b/src/driver/gen_rpc_driver_tcp.erl
@@ -210,7 +210,7 @@ set_socket_keepalive({unix, darwin}, Socket) ->
     {ok, KeepInterval} = application:get_env(?APP, socket_keepalive_interval),
     {ok, KeepCount} = application:get_env(?APP, socket_keepalive_count),
     ok = inet:setopts(Socket, [{raw, ?DARWIN_SOL_SOCKET, ?DARWIN_SO_KEEPALIVE, <<1:32/native>>}]),
-    ok = inet:setopts(Socket, [{raw, ?DARWIN_IPPROTO_TCP, ?DARWIN_TCP_KEEPIDLE, <<KeepIdle:32/native>>}]),
+    ok = inet:setopts(Socket, [{raw, ?DARWIN_IPPROTO_TCP, ?DARWIN_TCP_KEEPALIVE, <<KeepIdle:32/native>>}]),
     ok = inet:setopts(Socket, [{raw, ?DARWIN_IPPROTO_TCP, ?DARWIN_TCP_KEEPINTVL, <<KeepInterval:32/native>>}]),
     ok = inet:setopts(Socket, [{raw, ?DARWIN_IPPROTO_TCP, ?DARWIN_TCP_KEEPCNT, <<KeepCount:32/native>>}]),
     ok;


### PR DESCRIPTION
The raw socket flags set for Darwin and Linux is incorrect. This causes frequently TCP RPC connection down. See https://github.com/priestjim/gen_rpc/pull/79

Thanks for the effort and help got from [yy-chen](https://github.com/yy-chen).