### PR TITLE
Fix acceptor: do not crash on closed socket when setting opts

### DIFF
--- a/src/driver/gen_rpc_driver_ssl.erl
+++ b/src/driver/gen_rpc_driver_ssl.erl
@@ -86,10 +86,9 @@ send(Socket, Data) when is_tuple(Socket), is_binary(Data) ->
             ok
     end.
 
--spec activate_socket(ssl:sslsocket()) -> ok.
+-spec activate_socket(ssl:sslsocket()) -> ok | {error, inet:posix()}.
 activate_socket(Socket) when is_tuple(Socket) ->
-    ok = ssl:setopts(Socket, [{active,once}]),
-    ok.
+    ssl:setopts(Socket, [{active, once}]).
 
 %% Authenticate to a server
 -spec authenticate_server(ssl:sslsocket()) -> ok | {error, {badtcp | badrpc, term()}}.

--- a/src/driver/gen_rpc_driver_tcp.erl
+++ b/src/driver/gen_rpc_driver_tcp.erl
@@ -62,10 +62,9 @@ listen(Port) when is_integer(Port) ->
 accept(Socket) when is_port(Socket) ->
     gen_tcp:accept(Socket, infinity).
 
--spec activate_socket(port()) -> ok.
+-spec activate_socket(port()) -> ok | {error, inet:posix()}.
 activate_socket(Socket) when is_port(Socket) ->
-    ok = inet:setopts(Socket, [{active,true}]),
-    ok.
+    inet:setopts(Socket, [{active,true}]).
 
 -spec send(port(), binary()) -> ok | {error, term()}.
 send(Socket, Data) when is_port(Socket), is_binary(Data) ->


### PR DESCRIPTION
If the socket (port) is closed (by client) before sending
any data, acceptor may crash when setting active option.
In this commit, the error posix code is captured and logged,
then acceptor can stop.

test output:
```
(emqx@127.0.0.1)1> 2020-06-14 16:32:42.708 [info] event=client_connection_received driver=tcp socket="#Port<0.7>" action=starting_acceptor
2020-06-14 16:32:42.708 [info] event=start driver=tcp peer="127.0.0.1:42626"
2020-06-14 16:32:42.709 [notice] message=channel_closed before receiving any data driver=tcp socket="#Port<0.20>" peer="127.0.0.1:42626"
```