### PR TITLE
Fix dialyzer errors

### DIFF
--- a/src/gen_rpc_acceptor.erl
+++ b/src/gen_rpc_acceptor.erl
@@ -149,10 +149,10 @@ waiting_for_data(info, {Driver,Socket,Data},
                     reply_immediately({CallType, Caller, {badrpc,unauthorized}}, State)
             end;
         {cast, _M, _F, _A} = Cast ->
-            handle_cast(Cast, State),
+            _ = handle_cast(Cast, State),
             {keep_state_and_data, gen_rpc_helper:get_inactivity_timeout(?MODULE)};
         BatchCast when is_list(BatchCast) ->
-            [handle_cast(Cast, State) || Cast <- BatchCast],
+            _ = [handle_cast(Cast, State) || Cast <- BatchCast],
             {keep_state_and_data, gen_rpc_helper:get_inactivity_timeout(?MODULE)};
         {abcast, Name, Msg} ->
             _Result = case check_if_module_allowed(erlang, Control, List) of

--- a/src/gen_rpc_driver.erl
+++ b/src/gen_rpc_driver.erl
@@ -12,7 +12,7 @@
 
 -callback accept(term()) -> {ok, inet:socket() | ssl:sslsocket()} | {error, term()}.
 
--callback activate_socket(term()) -> ok.
+-callback activate_socket(term()) -> ok | {error, term()}.
 
 -callback authenticate_server(term()) -> ok | {error, {badtcp | badrpc, term()}}.
 

--- a/src/gen_rpc_keepalive.erl
+++ b/src/gen_rpc_keepalive.erl
@@ -22,12 +22,12 @@
 
 -export([start/3, check/1, cancel/1, resume/1]).
 
--record(keepalive, {statfun :: function(),
-                    statval :: integer(),
-                    tsec :: integer(),
-                    tmsg :: term(),
-                    tref :: reference(),
-                    repeat :: integer()}).
+-record(keepalive, {statfun :: function() | undefined,
+                    statval :: integer() | undefined,
+                    tsec :: integer() | undefined,
+                    tmsg :: term() | undefined,
+                    tref :: reference() | undefined,
+                    repeat :: integer() | undefined}).
 
 -type(keepalive() :: #keepalive{}).
 

--- a/src/gen_rpc_registry.erl
+++ b/src/gen_rpc_registry.erl
@@ -88,12 +88,12 @@ send(Name, Msg) ->
 
 -spec init([]) -> {ok, state()}.
 init([]) ->
-    ets:new(?TAB, [ named_table
-                  , protected
-                  , set
-                  , {read_concurrency, true}
-                  , {write_concurrency, false}
-                  ]),
+    ?TAB = ets:new(?TAB, [ named_table
+			 , protected
+			 , set
+			 , {read_concurrency, true}
+			 , {write_concurrency, false}
+			 ]),
     RLookup = ets:new(rlookup, [ set
                                , private
                                , {read_concurrency, false}


### PR DESCRIPTION
Fixes
```
src/driver/gen_rpc_driver_ssl.erl
Line 96 Column 2: The return type {'error',atom()} in the specification of activate_socket/1 is not a subtype of 'ok', which is the expected return type for the callback of gen_rpc_driver behaviour

src/driver/gen_rpc_driver_tcp.erl
Line 65 Column 2: The return type {'error',atom()} in the specification of activate_socket/1 is not a subtype of 'ok', which is the expected return type for the callback of gen_rpc_driver behaviour

src/gen_rpc_acceptor.erl
Line 152 Column 13: Expression produces a value of type 'ok' | pid(), but this value is unmatched
Line 155 Column 13: Expression produces a value of type ['ok' | pid()], but this value is unmatched

src/gen_rpc_keepalive.erl
Line 39 Column 10: Record construction #keepalive{statfun::'undefined',statval::'undefined',tsec::'undefined',tref::'undefined',repeat::'undefined'} violates the declared type of field statfun::fun() and statval::integer() and tsec::integer() and tref::reference() and repeat::integer()

src/gen_rpc_registry.erl
Line 91 Column 5: Expression produces a value of type atom() | ets:tid(), but this value is unmatched
```