### PR TITLE
fix common tests under otp24

### DIFF
--- a/test/remote_SUITE.erl
+++ b/test/remote_SUITE.erl
@@ -273,13 +273,15 @@ multiple_casts_test(_Config) ->
        fun(_Ret, Trace) ->
                %% 1. Check that all casts were received by a local client process before sending over net:
                ?assert(
-                  ?strict_causality( #{?snk_kind := test_cast, seqno := _SeqNo}
-                                   , #{?snk_kind := gen_rpc_cast, cast := {cast, gen_rpc_test_helper, test_call, [_SeqNo]}}
+                  ?strict_causality( #{?snk_kind := test_cast, seqno := _SeqNoA}
+                                   , #{?snk_kind := gen_rpc_cast, cast := {cast, gen_rpc_test_helper, test_call, [_SeqNoB]}}
+                                   , _SeqNoA == _SeqNoB
                                    , Trace
                                    )),
                ?assert(
-                  ?strict_causality( #{?snk_kind := gen_rpc_cast,      cast   := _Cast, sendto := _SendTo}
-                                   , #{?snk_kind := gen_rpc_send_cast, packet := _Cast, sendto := _SendTo}
+                  ?strict_causality( #{?snk_kind := gen_rpc_cast,      cast   := _CastA, sendto := _SendToA}
+                                   , #{?snk_kind := gen_rpc_send_cast, packet := _CastB, sendto := _SendToB}
+                                   , _CastA == _CastB andalso _SendToA == _SendToB
                                    , Trace
                                    )),
                %% 2. Check that no message reordering occurs on the client side:
@@ -288,8 +290,9 @@ multiple_casts_test(_Config) ->
                ?assertMatch([], ?of_kind(gen_rpc_error, Trace)),
                %% 4. Check delivery of the messages:
                ?assert(
-                  ?strict_causality( #{?snk_kind := gen_rpc_send_cast, packet := _Packet}
-                                   , #{?snk_kind := gen_rpc_acceptor_receive, packet := _Packet}
+                  ?strict_causality( #{?snk_kind := gen_rpc_send_cast, packet := _PacketA}
+                                   , #{?snk_kind := gen_rpc_acceptor_receive, packet := _PacketB}
+                                   , _PacketA == _PacketB
                                    , Trace
                                    )),
                %% 5. Check that all the messages were delivered:

--- a/test/remote_with_key_SUITE.erl
+++ b/test/remote_with_key_SUITE.erl
@@ -140,22 +140,22 @@ server_inactivity_timeout(_Config) ->
 random_local_tcp_close(_Config) ->
     {_Mega1, _Sec1, _Micro1} = rpc:call(?SLAVE, gen_rpc, call, [{?MASTER,random_key}, os, timestamp, []]),
     {_Mega2, _Sec2, _Micro2} = rpc:call(?SLAVE, gen_rpc, call, [{?MASTER,random_key2}, os, timestamp, []]),
-    [{_,AccPid,_,_}, _Other] = supervisor:which_children(gen_rpc_acceptor_sup),
+    [{_,AccPid,_,_}, Other] = supervisor:which_children(gen_rpc_acceptor_sup),
     true = erlang:exit(AccPid, kill),
     ok = timer:sleep(600), % Give some time to the supervisor to kill the children
     [?MASTER] = rpc:call(?SLAVE, gen_rpc, nodes, []),
-    [_Other] = supervisor:which_children(gen_rpc_acceptor_sup),
+    [Other] = supervisor:which_children(gen_rpc_acceptor_sup),
     [_Client] = rpc:call(?SLAVE, supervisor, which_children, [gen_rpc_client_sup]).
 
 random_remote_tcp_close(_Config) ->
     {_Mega1, _Sec1, _Micro1} = gen_rpc:call({?SLAVE,random_key}, os, timestamp),
     {_Mega2, _Sec2, _Micro2} = gen_rpc:call({?SLAVE,random_key2}, os, timestamp),
-    [{_,AccPid,_,_}, _Other] = rpc:call(?SLAVE, supervisor, which_children, [gen_rpc_acceptor_sup]),
+    [{_,AccPid,_,_}, Other] = rpc:call(?SLAVE, supervisor, which_children, [gen_rpc_acceptor_sup]),
     true = rpc:call(?SLAVE, erlang, exit, [AccPid,kill]),
     ok = timer:sleep(600),
     [?SLAVE] = gen_rpc:nodes(),
     [_Client] = supervisor:which_children(gen_rpc_client_sup),
-    [_Other] = rpc:call(?SLAVE, supervisor, which_children, [gen_rpc_acceptor_sup]).
+    [Other] = rpc:call(?SLAVE, supervisor, which_children, [gen_rpc_acceptor_sup]).
 
 %%% ===================================================
 %%% Auxiliary functions for test cases


### PR DESCRIPTION
since OTP-24.0 the compiler will emit warnings when (previously bound)
underscore-prefixed variables are matched.

the rebar3 ct task fails under otp24 since 'warnings_as_errors' is set.