### PR TITLE
feat(cast): New API for casts that preserves ordering

### DIFF
--- a/include/types.hrl
+++ b/include/types.hrl
@@ -5,4 +5,11 @@
 %%%
 
 %%% Node type
--type node_or_tuple() :: atom() | {atom(), term()}.
+-type destination() :: {node(), _Tag}.
+
+-type node_or_tuple() :: node() | destination().
+
+%% `gen_rpc' doesn't take advantage of atom indexing, so using short
+%% atom names saves a bit of bandwidth.
+-define(CAST(M, F, A), {cast, M, F, A}).
+-define(ORDERED_CAST(M, F, A), {oc, M, F, A}).

--- a/include/types.hrl
+++ b/include/types.hrl
@@ -10,6 +10,8 @@
 -type node_or_tuple() :: node() | destination().
 
 %% `gen_rpc' doesn't take advantage of atom indexing, so using short
-%% atom names saves a bit of bandwidth.
+%% atom names saves a little bit of bandwidth.
 -define(CAST(M, F, A), {cast, M, F, A}).
 -define(ORDERED_CAST(M, F, A), {oc, M, F, A}).
+
+-define(IS_CAST(MSG), ((MSG) =:= cast orelse (MSG) =:= oc)).

--- a/rebar.config
+++ b/rebar.config
@@ -30,7 +30,7 @@
     warn_exported_vars
 ]}.
 
-{deps, [ {snabbkaffe, {git, "https://github.com/kafka4beam/snabbkaffe", {tag, "0.15.0"}}}
+{deps, [ {snabbkaffe, {git, "https://github.com/kafka4beam/snabbkaffe", {tag, "0.17.1"}}}
        ]}.
 
 {profiles, [
@@ -84,6 +84,8 @@
         multi_rpc_with_key_SUITE
     ]}
 ]}.
+
+{ct_readable, false}.
 
 % Dialyzer
 {dialyzer, [

--- a/src/driver/gen_rpc_driver_ssl.erl
+++ b/src/driver/gen_rpc_driver_ssl.erl
@@ -103,9 +103,9 @@ authenticate_server(Socket) ->
     Cookie = erlang:get_cookie(),
     NodeStr = erlang:atom_to_list(node()),
     Packet = erlang:term_to_binary({gen_rpc_authenticate_connection, NodeStr, Cookie}),
-    SendTO = gen_rpc_helper:get_send_timeout(undefined),
-    RecvTO = gen_rpc_helper:get_call_receive_timeout(undefined),
-    ok = set_send_timeout(Socket, SendTO),
+    SendTimeout = gen_rpc_helper:get_send_timeout(undefined),
+    RecvTimeout = gen_rpc_helper:get_call_receive_timeout(undefined),
+    ok = set_send_timeout(Socket, SendTimeout),
     case ssl:send(Socket, Packet) of
         {error, Reason} ->
             ?log(error, "event=authentication_connection_failed socket=\"~s\" reason=\"~p\"",
@@ -114,7 +114,7 @@ authenticate_server(Socket) ->
             {error, {badtcp,Reason}};
         ok ->
             ?log(debug, "event=authentication_connection_succeeded socket=\"~s\"", [gen_rpc_helper:socket_to_string(Socket)]),
-            case ssl:recv(Socket, 0, RecvTO) of
+            case ssl:recv(Socket, 0, RecvTimeout) of
                 {ok, RecvPacket} ->
                     case erlang:binary_to_term(RecvPacket) of
                         gen_rpc_connection_authenticated ->
@@ -194,8 +194,8 @@ set_controlling_process(Socket, Pid) when is_tuple(Socket), is_pid(Pid) ->
     ssl:controlling_process(Socket, Pid).
 
 -spec set_send_timeout(ssl:sslsocket(), timeout() | undefined) -> ok.
-set_send_timeout(Socket, SendTO) when is_tuple(Socket) ->
-    ok = ssl:setopts(Socket, [{send_timeout, gen_rpc_helper:get_send_timeout(SendTO)}]),
+set_send_timeout(Socket, SendTimeout) when is_tuple(Socket) ->
+    ok = ssl:setopts(Socket, [{send_timeout, gen_rpc_helper:get_send_timeout(SendTimeout)}]),
     ok.
 
 -spec set_acceptor_opts(ssl:sslsocket()) -> ok.

--- a/src/driver/gen_rpc_driver_tcp.erl
+++ b/src/driver/gen_rpc_driver_tcp.erl
@@ -85,9 +85,9 @@ send(Socket, Data) when is_port(Socket), is_binary(Data) ->
 authenticate_server(Socket) ->
     Cookie = erlang:get_cookie(),
     Packet = erlang:term_to_binary({gen_rpc_authenticate_connection, Cookie}),
-    SendTO = gen_rpc_helper:get_send_timeout(undefined),
-    RecvTO = gen_rpc_helper:get_call_receive_timeout(undefined),
-    ok = set_send_timeout(Socket, SendTO),
+    SendTimeout = gen_rpc_helper:get_send_timeout(undefined),
+    RecvTimeout = gen_rpc_helper:get_call_receive_timeout(undefined),
+    ok = set_send_timeout(Socket, SendTimeout),
     case gen_tcp:send(Socket, Packet) of
         {error, Reason} ->
             ?log(error, "event=authentication_connection_failed socket=\"~s\" reason=\"~p\"",
@@ -96,7 +96,7 @@ authenticate_server(Socket) ->
             {error, {badtcp,Reason}};
         ok ->
             ?log(debug, "event=authentication_connection_succeeded socket=\"~s\"", [gen_rpc_helper:socket_to_string(Socket)]),
-            case gen_tcp:recv(Socket, 0, RecvTO) of
+            case gen_tcp:recv(Socket, 0, RecvTimeout) of
                 {ok, RecvPacket} ->
                     case erlang:binary_to_term(RecvPacket) of
                         gen_rpc_connection_authenticated ->
@@ -187,8 +187,8 @@ set_controlling_process(Socket, Pid) when is_port(Socket), is_pid(Pid) ->
     gen_tcp:controlling_process(Socket, Pid).
 
 -spec set_send_timeout(port(), timeout() | undefined) -> ok.
-set_send_timeout(Socket, SendTO) when is_port(Socket) ->
-    ok = inet:setopts(Socket, [{send_timeout, gen_rpc_helper:get_send_timeout(SendTO)}]),
+set_send_timeout(Socket, SendTimeout) when is_port(Socket) ->
+    ok = inet:setopts(Socket, [{send_timeout, gen_rpc_helper:get_send_timeout(SendTimeout)}]),
     ok.
 
 -spec set_acceptor_opts(port()) -> ok.

--- a/src/gen_rpc.erl
+++ b/src/gen_rpc.erl
@@ -59,12 +59,12 @@ call(Node, M, F, A) ->
 
 -spec call(node_or_tuple(), atom() | tuple(), atom() | function(), list(), timeout() | undefined) ->
     term() | {badrpc, term()} | {badtcp | term()}.
-call(Node, M, F, A, RecvTO) ->
-    gen_rpc_client:call(Node, M, F, A, RecvTO).
+call(Node, M, F, A, RecvTimeout) ->
+    gen_rpc_client:call(Node, M, F, A, RecvTimeout).
 
 -spec call(node_or_tuple(), atom() | tuple(), atom() | function(), list(), timeout() | undefined, timeout() | undefined) -> term() | {badrpc, term()} | {badtcp | term()}.
-call(Node, M, F, A, RecvTO, SendTO) ->
-    gen_rpc_client:call(Node, M, F, A, RecvTO, SendTO).
+call(Node, M, F, A, RecvTimeout, SendTimeout) ->
+    gen_rpc_client:call(Node, M, F, A, RecvTimeout, SendTimeout).
 
 -spec cast(node_or_tuple(), atom() | tuple(), atom() | function()) -> true.
 cast(Node, M, F) ->
@@ -75,8 +75,8 @@ cast(Node, M, F, A) ->
     gen_rpc_client:cast(Node, M, F, A).
 
 -spec cast(node_or_tuple(), atom() | tuple(), atom() | function(), list(), timeout() | undefined) -> true.
-cast(Node, M, F, A, SendTO) ->
-    gen_rpc_client:cast(Node, M, F, A, SendTO).
+cast(Node, M, F, A, SendTimeout) ->
+    gen_rpc_client:cast(Node, M, F, A, SendTimeout).
 
 -spec eval_everywhere([node_or_tuple()], atom() | tuple(), atom() | function()) -> abcast.
 eval_everywhere(Nodes, M, F) ->
@@ -87,8 +87,8 @@ eval_everywhere(Nodes, M, F, A) ->
     gen_rpc_client:eval_everywhere(Nodes, M, F, A).
 
 -spec eval_everywhere([node_or_tuple()], atom() | tuple(), atom() | function(), list(), timeout() | undefined) -> abcast.
-eval_everywhere(Nodes, M, F, A, SendTO) ->
-    gen_rpc_client:eval_everywhere(Nodes, M, F, A, SendTO).
+eval_everywhere(Nodes, M, F, A, SendTimeout) ->
+    gen_rpc_client:eval_everywhere(Nodes, M, F, A, SendTimeout).
 
 -spec yield(tuple()) -> term() | {badrpc, term()}.
 yield(Key) ->

--- a/src/gen_rpc_acceptor.erl
+++ b/src/gen_rpc_acceptor.erl
@@ -148,7 +148,7 @@ waiting_for_data(info, {Driver,Socket,Data},
                          [Driver, gen_rpc_helper:socket_to_string(Socket), Control, CallType, RealM]),
                     reply_immediately({CallType, Caller, {badrpc,unauthorized}}, State)
             end;
-        {cast, _M, _F, _A} = Cast ->
+        ?CAST(_M, _F, _A) = Cast ->
             _ = handle_cast(Cast, State),
             {keep_state_and_data, gen_rpc_helper:get_inactivity_timeout(?MODULE)};
         BatchCast when is_list(BatchCast) ->
@@ -321,7 +321,7 @@ check_module_version_compat({M, Version}) ->
 check_module_version_compat(M) ->
     {true, M}.
 
-handle_cast({cast, M, F, A}, #state{socket=Socket, driver=Driver, peer=Peer, control=Control, list=List}) ->
+handle_cast(?CAST(M, F, A), #state{socket=Socket, driver=Driver, peer=Peer, control=Control, list=List}) ->
     {ModVsnAllowed, RealM} = check_module_version_compat(M),
     case check_if_module_allowed(RealM, Control, List) of
         true ->

--- a/src/gen_rpc_client.erl
+++ b/src/gen_rpc_client.erl
@@ -441,8 +441,9 @@ send_cast(PacketTuple, #state{socket=Socket, driver=Driver, driver_mod=DriverMod
                                        }),
             {stop, Reason, State};
         ok ->
-            ok = if Activate =:= true -> DriverMod:activate_socket(Socket);
-                    true -> ok
+            ok = case Activate of
+                     true -> DriverMod:activate_socket(Socket);
+                     _    -> ok
                  end,
             ?log(debug, "message=cast event=transmission_succeeded driver=~s socket=\"~s\"",
                  [Driver, gen_rpc_helper:socket_to_string(Socket)]),

--- a/src/gen_rpc_client.erl
+++ b/src/gen_rpc_client.erl
@@ -83,16 +83,16 @@ call(NodeOrTuple, M, F, A) ->
 
 %% Simple server call with custom receive timeout value
 -spec call(node_or_tuple(), atom() | tuple(), atom() | function(), list(), timeout()) -> term() | {badrpc,term()} | {badtcp,term()}.
-call(NodeOrTuple, M, F, A, RecvTO) ->
-    call(NodeOrTuple, M, F, A, RecvTO, undefined).
+call(NodeOrTuple, M, F, A, RecvTimeout) ->
+    call(NodeOrTuple, M, F, A, RecvTimeout, undefined).
 
 %% Simple server call with custom receive and send timeout values
 %% This is the function that all of the above call
 -spec call(node_or_tuple(), atom() | tuple(), atom() | function(), list(), timeout() | undefined, timeout() | undefined) ->
     term() | {badrpc,term()} | {badtcp,term()}.
-call(NodeOrTuple, M, F, A, RecvTO, SendTO) when ?is_node_or_tuple(NodeOrTuple), is_atom(M) orelse is_tuple(M), is_atom(F), is_list(A),
-                                         RecvTO =:= undefined orelse ?is_timeout(RecvTO),
-                                         SendTO =:= undefined orelse ?is_timeout(SendTO) ->
+call(NodeOrTuple, M, F, A, RecvTimeout, SendTimeout) when ?is_node_or_tuple(NodeOrTuple), is_atom(M) orelse is_tuple(M), is_atom(F), is_list(A),
+                                         RecvTimeout =:= undefined orelse ?is_timeout(RecvTimeout),
+                                         SendTimeout =:= undefined orelse ?is_timeout(SendTimeout) ->
     %% Create a unique name for the client because we register as such
     PidName = ?NAME(NodeOrTuple),
     case gen_rpc_registry:whereis_name(PidName) of
@@ -104,7 +104,7 @@ call(NodeOrTuple, M, F, A, RecvTO, SendTO) when ?is_node_or_tuple(NodeOrTuple), 
                     %% This is not resilient enough if the caller's mailbox is full
                     %% but it's good enough for now
                     try
-                        gen_server:call(NewPid, {{call,M,F,A}, SendTO}, gen_rpc_helper:get_call_receive_timeout(RecvTO))
+                        gen_server:call(NewPid, {{call,M,F,A}, SendTimeout}, gen_rpc_helper:get_call_receive_timeout(RecvTimeout))
                     catch
                         exit:{timeout,_Reason} -> {badrpc,timeout};
                         exit:OtherReason -> {badrpc, {unknown_error, OtherReason}}
@@ -115,7 +115,7 @@ call(NodeOrTuple, M, F, A, RecvTO, SendTO) when ?is_node_or_tuple(NodeOrTuple), 
         Pid ->
             ?log(debug, "event=client_process_found pid=\"~p\" target=\"~p\"", [Pid, NodeOrTuple]),
             try
-                gen_server:call(Pid, {{call,M,F,A}, SendTO}, gen_rpc_helper:get_call_receive_timeout(RecvTO))
+                gen_server:call(Pid, {{call,M,F,A}, SendTimeout}, gen_rpc_helper:get_call_receive_timeout(RecvTimeout))
             catch
                 exit:{timeout,_Reason} -> {badrpc,timeout};
                 exit:OtherReason -> {badrpc, {unknown_error, OtherReason}}
@@ -152,9 +152,9 @@ eval_everywhere(Nodes, M, F, A) ->
 
 %% Evaluate {M, F, A} on connected nodes.
 -spec eval_everywhere([atom()], atom() | tuple(), atom() | function(), list(), timeout() | undefined) -> abcast.
-eval_everywhere(Nodes, M, F, A, SendTO) when is_list(Nodes), is_atom(M) orelse is_tuple(M), is_atom(F), is_list(A),
-                                             SendTO =:= undefined orelse ?is_timeout(SendTO) ->
-    _ = [erlang:spawn(?MODULE, cast_worker, [Node, {cast,M,F,A}, abcast, SendTO]) || Node <- Nodes],
+eval_everywhere(Nodes, M, F, A, SendTimeout) when is_list(Nodes), is_atom(M) orelse is_tuple(M), is_atom(F), is_list(A),
+                                             SendTimeout =:= undefined orelse ?is_timeout(SendTimeout) ->
+    _ = [erlang:spawn(?MODULE, cast_worker, [Node, ?CAST(M, F, A), abcast, SendTimeout]) || Node <- Nodes],
     abcast.
 
 %% Simple server async_call with no args
@@ -289,11 +289,11 @@ init({Node}) ->
     end.
 
 %% This is the actual CALL handler
-handle_call({{call,_M,_F,_A} = PacketTuple, SendTO}, Caller, #state{socket=Socket, driver=Driver, driver_mod=DriverMod} = State) ->
+handle_call({{call,_M,_F,_A} = PacketTuple, SendTimeout}, Caller, #state{socket=Socket, driver=Driver, driver_mod=DriverMod} = State) ->
     Packet = erlang:term_to_binary({PacketTuple, Caller}),
     ?log(debug, "message=call event=constructing_call_term driver=~s socket=\"~s\" caller=\"~p\"",
          [Driver, gen_rpc_helper:socket_to_string(Socket), Caller]),
-    ok = DriverMod:set_send_timeout(Socket, SendTO),
+    ok = DriverMod:set_send_timeout(Socket, SendTimeout),
     case DriverMod:send(Socket, Packet) of
         {error, Reason} ->
             ?log(error, "message=call event=transmission_failed driver=~s socket=\"~s\" caller=\"~p\" reason=\"~p\"",
@@ -423,14 +423,14 @@ terminate(_Reason, #state{keepalive=KeepAlive}) ->
 %%% ===================================================
 %%% Private functions
 %%% ===================================================
-send_cast(PacketTuple, #state{socket=Socket, driver=Driver, driver_mod=DriverMod} = State, SendTO, Activate) ->
-    ?tp(gen_rpc_send_cast, #{ sendto => SendTO
+send_cast(PacketTuple, #state{socket=Socket, driver=Driver, driver_mod=DriverMod} = State, SendTimeout, Activate) ->
+    ?tp(gen_rpc_send_cast, #{ sendto => SendTimeout
                             , packet => PacketTuple
                             , driver => Driver
                             , socket => gen_rpc_helper:socket_to_string(Socket)
                             }),
     Packet = erlang:term_to_binary(PacketTuple),
-    ok = DriverMod:set_send_timeout(Socket, SendTO),
+    ok = DriverMod:set_send_timeout(Socket, SendTimeout),
     case DriverMod:send(Socket, Packet) of
         {error, Reason} ->
             ?tp(error, gen_rpc_error, #{ error  => transmission_failed
@@ -465,12 +465,12 @@ send_ping(#state{socket=Socket, driver=Driver, driver_mod=DriverMod} = State) ->
             {noreply, State, gen_rpc_helper:get_inactivity_timeout(?MODULE)}
     end.
 
-cast_worker(NodeOrTuple, Cast, Ret, SendTO) ->
+cast_worker(NodeOrTuple, Cast, Ret, SendTimeout) ->
     %% Create a unique name for the client because we register as such
     PidName = ?NAME(NodeOrTuple),
     ?tp(gen_rpc_cast, #{ cast => Cast
                        , target => NodeOrTuple
-                       , sendto => SendTO
+                       , sendto => SendTimeout
                        , pid => PidName
                        }),
     case gen_rpc_registry:whereis_name(PidName) of
@@ -481,14 +481,14 @@ cast_worker(NodeOrTuple, Cast, Ret, SendTO) ->
                     %% We take care of CALL inside the gen_server
                     %% This is not resilient enough if the caller's mailbox is full
                     %% but it's good enough for now
-                    erlang:send(NewPid, {Cast, SendTO}),
+                    erlang:send(NewPid, {Cast, SendTimeout}),
                     Ret;
                 {error, _Reason} ->
                     Ret
             end;
         Pid ->
             ?tp(debug, gen_rpc_client_process_found, #{pid => Pid, target => NodeOrTuple}),
-            erlang:send(Pid, {Cast, SendTO}),
+            erlang:send(Pid, {Cast, SendTimeout}),
             Ret
     end.
 

--- a/src/gen_rpc_client.erl
+++ b/src/gen_rpc_client.erl
@@ -140,8 +140,6 @@ cast(NodeOrTuple, M, F, A, SendTimeout) when ?is_node_or_tuple(NodeOrTuple), is_
     cast_worker(NodeOrTuple, ?CAST(M, F, A), undefined, SendTimeout),
     true.
 
-%% Simple server cast with custom send timeout value
-%% This is the function that all of the above casts call
 -spec ordered_cast(destination(), atom() | tuple(), atom() | function(), list()) -> true.
 ordered_cast(NodeOrTuple, M, F, A) when ?is_node_or_tuple(NodeOrTuple), is_atom(M) orelse is_tuple(M), is_atom(F), is_list(A) ->
     cast_worker(NodeOrTuple, ?ORDERED_CAST(M, F, A), undefined, undefined),
@@ -476,8 +474,7 @@ send_ping(#state{socket=Socket, driver=Driver, driver_mod=DriverMod} = State) ->
 cast_worker(NodeOrTuple, Cast, Ret, SendTimeout) ->
     %% Create a unique name for the client because we register as such
     PidName = ?NAME(NodeOrTuple),
-    ?tp(gen_rpc_input, #{ type => cast
-                        , input => Cast
+    ?tp(gen_rpc_input, #{ input => Cast
                         , target => NodeOrTuple
                         , sendto => SendTimeout
                         , pid => PidName

--- a/src/gen_rpc_helper.erl
+++ b/src/gen_rpc_helper.erl
@@ -161,8 +161,8 @@ get_connect_timeout() ->
 %% Merges user-defined call receive timeout values with app timeout values
 -spec get_call_receive_timeout(undefined | timeout()) -> timeout().
 get_call_receive_timeout(undefined) ->
-    {ok, RecvTO} = application:get_env(?APP, call_receive_timeout),
-    RecvTO;
+    {ok, RecvTimeout} = application:get_env(?APP, call_receive_timeout),
+    RecvTimeout;
 
 get_call_receive_timeout(Else) ->
     Else.
@@ -186,20 +186,20 @@ get_authentication_timeout() ->
 %% Returns the default sbcast receive timeout
 -spec get_sbcast_receive_timeout() -> timeout().
 get_sbcast_receive_timeout() ->
-    {ok, RecvTO} = application:get_env(?APP, sbcast_receive_timeout),
-    RecvTO.
+    {ok, RecvTimeout} = application:get_env(?APP, sbcast_receive_timeout),
+    RecvTimeout.
 
 %% Returns the default dispatch receive timeout
 -spec get_control_receive_timeout() -> timeout().
 get_control_receive_timeout() ->
-    {ok, RecvTO} = application:get_env(?APP, control_receive_timeout),
-    RecvTO.
+    {ok, RecvTimeout} = application:get_env(?APP, control_receive_timeout),
+    RecvTimeout.
 
 %% Merges user-defined send timeout values with app timeout values
 -spec get_send_timeout(undefined | timeout()) -> timeout().
 get_send_timeout(undefined) ->
-    {ok, SendTO} = application:get_env(?APP, send_timeout),
-    SendTO;
+    {ok, SendTimeout} = application:get_env(?APP, send_timeout),
+    SendTimeout;
 get_send_timeout(Else) ->
     Else.
 

--- a/test/gen_rpc_trace_props.erl
+++ b/test/gen_rpc_trace_props.erl
@@ -1,0 +1,61 @@
+-module(gen_rpc_trace_props).
+
+-export([common_bundle/0, cast_bundle/0]).
+
+-export([client_receive_all_casts/1, no_known_error_reports/1, no_reordering_on_client_side/1,
+         transport_delivery/1, all_casts_are_executed/1]).
+
+-include_lib("stdlib/include/assert.hrl").
+-include_lib("snabbkaffe/include/test_macros.hrl").
+
+cast_bundle() ->
+    [ fun ?MODULE:client_receive_all_casts/1
+    , fun ?MODULE:all_casts_are_executed/1
+    , fun ?MODULE:no_reordering_on_client_side/1
+    | common_bundle()
+    ].
+
+common_bundle() ->
+    [ fun ?MODULE:no_known_error_reports/1
+    , fun ?MODULE:transport_delivery/1
+    ].
+
+%%% Common trace specs:
+
+no_known_error_reports(Trace) ->
+    ?assertMatch([], ?of_kind(gen_rpc_error, Trace)).
+
+transport_delivery(Trace) ->
+    %% Check that packets are not lost:
+    ?assert(
+       ?strict_causality( #{?snk_kind := gen_rpc_send_packet, packet := _Packet}
+                        , #{?snk_kind := gen_rpc_acceptor_receive, packet := _Packet}
+                        , Trace
+                        )).
+
+
+%% TODO: Make this check more generic, so it can be safely bundled
+no_reordering_on_client_side(Trace) ->
+    snabbkaffe:strictly_increasing(?projection(packet, ?of_kind(gen_rpc_send_packet, Trace))).
+
+%%% Checks related to cast messages:
+
+%% Check that all test casts were received by a local client process before sending over net:
+client_receive_all_casts(Trace) ->
+    ?assert(
+       ?strict_causality( #{?snk_kind := test_cast, seqno := _SeqNo}
+                        , #{?snk_kind := gen_rpc_input, input := {_cast, gen_rpc_test_helper, test_call, [_SeqNo]}}
+                        , Trace
+                        )),
+    ?assert(
+       ?strict_causality( #{?snk_kind := gen_rpc_input,       input  := _Msg}
+                        , #{?snk_kind := gen_rpc_send_packet, packet := _Msg}
+                        , Trace
+                        )).
+
+%% Check that all casts initiated by the testcase were executed on the remote side:
+all_casts_are_executed(Trace) ->
+    ?strict_causality( #{?snk_kind := test_cast,    seqno := _SeqNo}
+                     , #{?snk_kind := do_test_call, seqno := _SeqNo}
+                     , Trace
+                     ).

--- a/test/gen_rpc_trace_props.erl
+++ b/test/gen_rpc_trace_props.erl
@@ -55,7 +55,8 @@ client_receive_all_casts(Trace) ->
 
 %% Check that all casts initiated by the testcase were executed on the remote side:
 all_casts_are_executed(Trace) ->
-    ?strict_causality( #{?snk_kind := test_cast,    seqno := _SeqNo}
-                     , #{?snk_kind := do_test_call, seqno := _SeqNo}
-                     , Trace
-                     ).
+    ?assert(
+       ?strict_causality( #{?snk_kind := test_cast,    seqno := _SeqNo}
+                        , #{?snk_kind := do_test_call, seqno := _SeqNo}
+                        , Trace
+                        )).


### PR DESCRIPTION
`gen_rpc:cast` doesn't give any guarantees about the order in which the casts are executed. This PR introduces a new API that is free of this problem.