### PR TITLE
fix: make `start_child` pass driver to `gen_rpc_acceptor:start_link/2`

### DIFF
--- a/src/supervisor/gen_rpc_acceptor_sup.erl
+++ b/src/supervisor/gen_rpc_acceptor_sup.erl
@@ -35,7 +35,7 @@ start_child(Driver, Peer) when is_tuple(Peer) ->
         {error, {already_started, CPid}} ->
             %% If we've already started the child, terminate it and start anew
             ok = stop_child(CPid),
-            supervisor:start_child(?MODULE, [Peer]);
+            supervisor:start_child(?MODULE, [Driver, Peer]);
         {error, OtherError} ->
             {error, OtherError};
         {ok, Pid} ->


### PR DESCRIPTION
If, for some reason, we call `gen_rpc_acceptor_sup:start_child` with a
`{Driver, Peer}` pair that is already started, it'll try to terminate
it and start anew.  But, on this second attempt, it only passes down
the `Peer`, and there is no `start_link/1` in `gen_rpc_acceptor`.