### PR TITLE
fix `sync` dependency url

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -49,7 +49,7 @@
             warnings_as_errors,
             no_inline_list_funcs]},
         {deps, [
-            {sync, {git, "git://github.com/rustyio/sync.git", {branch, "master"}}}
+            {sync, {git, "https://github.com/rustyio/sync.git", {branch, "master"}}}
         ]}
     ]}
 ]}.


### PR DESCRIPTION
It's breaking in CI and locally when using the `git` scheme.

```
===> Verifying dependencies...
===> Fetching sync (from {git,"git://github.com/rustyio/sync.git",{branch,"master"}})
===> Failed to fetch and copy dep: {git,"git://github.com/rustyio/sync.git",
                                   {branch,"master"}}
make: *** [Makefile:87: all] Error 1
```