### PR TITLE
fix: peer address formating

### DIFF
--- a/src/gen_rpc_helper.erl
+++ b/src/gen_rpc_helper.erl
@@ -47,15 +47,13 @@
 %%% Public API
 %%% ===================================================
 %% Return the connected peer's IP
--spec peer_to_string({inet:ip4_address(), inet:port_number()} | inet:ip4_address()) -> string().
-peer_to_string({{A,B,C,D}, Port}) when is_integer(A), is_integer(B), is_integer(C), is_integer(D), is_integer(Port) ->
-    integer_to_list(A) ++ "." ++
-    integer_to_list(B) ++ "." ++
-    integer_to_list(C) ++ "." ++
-    integer_to_list(D) ++ ":" ++
-    integer_to_list(Port);
-peer_to_string({A,B,C,D} = IpAddress) when is_integer(A), is_integer(B), is_integer(C), is_integer(D) ->
-    peer_to_string({IpAddress, 0}).
+-spec peer_to_string({inet:ip_address(), inet:port_number()} | inet:ip_address()) -> string().
+peer_to_string({Ip, Port}) when tuple_size(Ip) =:= 4 ->
+    inet:ntoa(Ip) ++ ":" ++ integer_to_list(Port);
+peer_to_string({Ip, Port}) when tuple_size(Ip) =:= 8 ->
+    "[" ++ inet:ntoa(Ip) ++ "]:" ++ integer_to_list(Port);
+peer_to_string(Ip) when is_tuple(Ip) andalso (tuple_size(Ip) =:= 4 orelse tuple_size(Ip) =:= 8) ->
+    peer_to_string({Ip, 0}).
 
 -spec socket_to_string(term()) -> string().
 socket_to_string(Socket) when is_port(Socket) ->


### PR DESCRIPTION
support ipv6
`peer="[::ffff:127.0.0.1]:47640"`

e.g.
2023-10-02T13:16:44.653177+02:00 [debug] event=call_received driver=tcp socket="#Port<0.18>" peer="[::ffff:127.0.0.1]:47640"