### PR TITLE
chore: reduce debug level logging in tcp driver

### DIFF
--- a/src/driver/gen_rpc_driver_tcp.erl
+++ b/src/driver/gen_rpc_driver_tcp.erl
@@ -84,7 +84,6 @@ send(Socket, Data) when is_port(Socket) ->
             ?log(error, "event=send_data_failed socket=\"~s\" reason=\"~p\"", [gen_rpc_helper:socket_to_string(Socket), Reason]),
             {error, {badtcp,Reason}};
         ok ->
-            ?log(debug, "event=send_data_succeeded socket=\"~s\"", [gen_rpc_helper:socket_to_string(Socket)]),
             ok
     end.
 
@@ -95,7 +94,6 @@ send_async(Socket, Data) when is_port(Socket) ->
             ?log(error, "event=send_async_failed socket=\"~s\" reason=\"~p\"", [gen_rpc_helper:socket_to_string(Socket), Reason]),
             {error, {badtcp,Reason}};
         ok ->
-            ?log(debug, "event=send_async_succeeded socket=\"~s\"", [gen_rpc_helper:socket_to_string(Socket)]),
             ok
     end.
 


### PR DESCRIPTION

```
2025-05-14T17:07:28.645767+00:00 [debug] event=ping_received driver=tcp socket="#Port<0.83>" peer="10.89.0.4:58296" action=ignore
```