### PR TITLE
perf: use lazy tracepoints in hot code paths

### DIFF
--- a/include/logger.hrl
+++ b/include/logger.hrl
@@ -39,5 +39,10 @@
 
 -define(log(Level, Format, Args),
         begin
-          (logger:log(Level,#{},#{report_cb => fun(_) -> {(Format), (Args)} end}))
+          (logger:log(Level,fun(_) -> {(Format), (Args)} end,[]))
+        end).
+
+-define(slog(Level, Report),
+        begin
+          (logger:log(Level,fun(_) -> Report end, []))
         end).

--- a/src/gen_rpc_client.erl
+++ b/src/gen_rpc_client.erl
@@ -346,7 +346,8 @@ handle_info({{sbcast,_Name,_Msg,_Caller} = PacketTuple, undefined}, State) ->
 %% Handle any TCP packet coming in
 handle_info({Driver,Socket,Data}, #state{socket=Socket, driver=Driver, driver_mod=DriverMod} = State) ->
     MessageFromWire = erlang:binary_to_term(Data),
-    ?tp(gen_rpc_client_receive_message, #{ socket => gen_rpc_helper:socket_to_string(Socket)
+    ?tp_ignore_side_effects_in_prod(
+        gen_rpc_client_receive_message, #{ socket => gen_rpc_helper:socket_to_string(Socket)
                                          , packet => MessageFromWire
                                          }),
     _Reply = case MessageFromWire of
@@ -420,7 +421,8 @@ terminate(_Reason, #state{keepalive=KeepAlive}) ->
 %%% Private functions
 %%% ===================================================
 send_cast(PacketTuple, #state{socket=Socket, driver=Driver, driver_mod=DriverMod} = State, SendTimeout, Activate) ->
-    ?tp(gen_rpc_send_packet, #{ packet  => PacketTuple
+    ?tp_ignore_side_effects_in_prod(
+        gen_rpc_send_packet, #{ packet  => PacketTuple
                               , timeout => SendTimeout
                               , driver  => Driver
                               , socket  => gen_rpc_helper:socket_to_string(Socket)
@@ -465,7 +467,8 @@ send_ping(#state{socket=Socket, driver=Driver, driver_mod=DriverMod} = State) ->
 cast_worker(NodeOrTuple, Cast, Ret, SendTimeout) ->
     %% Create a unique name for the client because we register as such
     PidName = ?NAME(NodeOrTuple),
-    ?tp(gen_rpc_input, #{ input => Cast
+    ?tp_ignore_side_effects_in_prod(
+        gen_rpc_input, #{ input => Cast
                         , target => NodeOrTuple
                         , sendto => SendTimeout
                         , pid => PidName
@@ -484,7 +487,8 @@ cast_worker(NodeOrTuple, Cast, Ret, SendTimeout) ->
                     Ret
             end;
         Pid ->
-            ?tp(debug, gen_rpc_client_process_found, #{pid => Pid, target => NodeOrTuple}),
+            ?tp_ignore_side_effects_in_prod(
+                gen_rpc_client_process_found, #{pid => Pid, target => NodeOrTuple}),
             erlang:send(Pid, {Cast, SendTimeout}),
             Ret
     end.


### PR DESCRIPTION
Before this PR, few tracepoints and log reports evaluated eagerly (even if log events were later thrown away due to logging level cutoff). This manifested in considerable amount of perf samples pointing to the changed code in performance benchmark workloads I've been running involving heavy use of `gen_rpc`.

Use lazily evaluated tracepoints / log reports in few hot paths instead to alleviate this performance cost.