### PR TITLE
fix: nb_yield type spec

### DIFF
--- a/src/gen_rpc_client.erl
+++ b/src/gen_rpc_client.erl
@@ -169,12 +169,12 @@ yield(Key) ->
     Result.
 
 %% Simple server non-blocking yield with key, default timeout value of 0
--spec nb_yield(tuple()) -> {value,term()} | {badrpc,term()}.
+-spec nb_yield(tuple()) -> {value,term() | {badrpc,term()}} | timeout.
 nb_yield(Key)->
     nb_yield(Key, 0).
 
 %% Simple server non-blocking yield with key and custom timeout value
--spec nb_yield(tuple(), timeout()) -> {value,term()} | {badrpc,term()}.
+-spec nb_yield(tuple(), timeout()) -> {value,term() | {badrpc,term()}} | timeout.
 nb_yield({Pid,Ref}, Timeout) when is_pid(Pid), is_reference(Ref), ?is_timeout(Timeout) ->
     Pid ! {self(), Ref, yield},
     receive


### PR DESCRIPTION
Fix the type specs on `nb_yield`. As seen here on the tests the possible results:

https://github.com/emqx/gen_rpc/blob/6a6164ef052368cc37481b633fda37566df65d10/test/local_SUITE.erl#L197


https://github.com/emqx/gen_rpc/blob/6a6164ef052368cc37481b633fda37566df65d10/test/local_SUITE.erl#L179