### PR TITLE
feat: add server port precheck api and tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 Below is a non-exhaustive list of changes between `gen_rpc` versions.
 
+## 3.6.0
+
+- Support compression when serializing Erlang term to binary.
+- Add `gen_rpc:check_server_ports_available/0` to help checking if `Address:Port` is in use.
+
 ## 3.5.1
 
 - Fix log 'domain' metadata.

--- a/src/gen_rpc.erl
+++ b/src/gen_rpc.erl
@@ -32,7 +32,7 @@
 -export([sbcast/2, sbcast/3]).
 
 %% Misc functions
--export([nodes/0]).
+-export([nodes/0, check_server_ports_available/0]).
 
 %% Set logger module
 -export([set_logger/1]).
@@ -147,6 +147,10 @@ sbcast(Nodes, Name, Msg) when is_list(Nodes), is_atom(Name) ->
 -spec nodes() -> list().
 nodes() ->
     gen_rpc_registry:nodes().
+
+-spec check_server_ports_available() -> ok | {error, [map()]}.
+check_server_ports_available() ->
+    gen_rpc_helper:check_server_ports_available().
 
 -spec set_logger(module()) -> ok.
 set_logger(Module) ->

--- a/src/gen_rpc_client.erl
+++ b/src/gen_rpc_client.erl
@@ -107,12 +107,13 @@ call(NodeOrTuple, M, F, A, RecvTimeout, SendTimeout) when ?is_node_or_tuple(Node
             catch
                 exit:{timeout,_Reason} -> {badrpc,timeout};
                 exit:{{shutdown, {badrpc, Reason}}, {gen_server, call, _}} ->
-                    %% the client gen_server stopped in handle_continue
+                    %% The client gen_server stopped in handle_continue.
                     {badrpc, Reason};
                 exit:{{shutdown, Reason}, {gen_server, call, _}} ->
-                    %% the client gen_server stopped with shutdown reason (non-badrpc)
+                    %% The client gen_server stopped with shutdown reason (non-badrpc).
                     {badrpc, Reason};
-                exit:OtherReason -> {badrpc, {unknown_error, OtherReason}}
+                exit:OtherReason ->
+                    {badrpc, {unknown_error, OtherReason}}
             end;
         {error, Reason} ->
             Reason
@@ -296,12 +297,14 @@ handle_continue({connect, Node, Port, Key}, #state{driver_mod = DriverMod, drive
                     {stop, {shutdown, Error}, State}
             end;
         {error, ReasonTuple} ->
-            ?log(error, "client_authentication_failed",
-                 #{driver => Driver,
-                   node => Node,
-                   port => Port,
-                   key => Key,
-                   cause => ReasonTuple}),
+            ?tp(error, client_authentication_failed, #{
+                driver => Driver,
+                node => Node,
+                port => Port,
+                key => Key,
+                cause => ReasonTuple,
+                domain => ?D_CLIENT
+            }),
             {stop, {shutdown, ReasonTuple}, State};
         {unreachable, Reason} ->
             %% This should be badtcp but to conform with

--- a/src/gen_rpc_helper.erl
+++ b/src/gen_rpc_helper.erl
@@ -234,7 +234,6 @@ get_user_tcp_opts(Type) ->
 
 -spec check_server_ports_available() -> ok | {error, [map()]}.
 check_server_ports_available() ->
-    _ = application:load(?APP),
     Endpoints = server_listen_endpoints(),
     case find_port_conflicts(Endpoints) of
         [] -> ok;

--- a/test/gen_rpc_port_check_tests.erl
+++ b/test/gen_rpc_port_check_tests.erl
@@ -1,0 +1,144 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2026 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+
+-module(gen_rpc_port_check_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-define(APP, gen_rpc).
+
+check_server_ports_available_stateless_conflict_test() ->
+    Port = gen_rpc_helper:port(node()),
+    maybe_with_blocker(
+        Port,
+        fun() ->
+            with_env(
+                #{
+                    port_discovery => stateless,
+                    tcp_server_port => 5369,
+                    ssl_server_port => false
+                },
+                fun() ->
+                    ?assertMatch(
+                        {error, [#{driver := tcp, port := Port, reason := eaddrinuse}]},
+                        gen_rpc:check_server_ports_available()
+                    )
+                end
+            )
+        end
+    ).
+
+check_server_ports_available_manual_conflict_test() ->
+    {ok, Blocker} = gen_tcp:listen(0, [binary, {reuseaddr, true}, {active, false}, {ip, {127, 0, 0, 1}}]),
+    {ok, {_, Port}} = inet:sockname(Blocker),
+    try
+        with_env(
+            #{
+                port_discovery => manual,
+                tcp_server_port => Port,
+                ssl_server_port => false
+            },
+            fun() ->
+                ?assertMatch(
+                    {error, [#{driver := tcp, port := Port, reason := eaddrinuse}]},
+                    gen_rpc:check_server_ports_available()
+                )
+            end
+        )
+    after
+        ok = gen_tcp:close(Blocker)
+    end.
+
+check_server_ports_available_manual_conflict_ipv6_test() ->
+    with_ipv6_support(
+        fun() ->
+            {ok, Blocker} = gen_tcp:listen(
+                0,
+                [binary, inet6, {reuseaddr, true}, {active, false}, {ip, {0, 0, 0, 0, 0, 0, 0, 1}}]
+            ),
+            {ok, {_, Port}} = inet:sockname(Blocker),
+            try
+                with_env(
+                    #{
+                        port_discovery => manual,
+                        tcp_server_port => Port,
+                        ssl_server_port => false,
+                        socket_ip => {0, 0, 0, 0, 0, 0, 0, 1}
+                    },
+                    fun() ->
+                        ?assertMatch(
+                            {error, [#{
+                                driver := tcp,
+                                ip := {0, 0, 0, 0, 0, 0, 0, 1},
+                                port := Port,
+                                reason := eaddrinuse
+                            }]},
+                            gen_rpc:check_server_ports_available()
+                        )
+                    end
+                )
+            after
+                ok = gen_tcp:close(Blocker)
+            end
+        end
+    ).
+
+maybe_with_blocker(Port, Fun) ->
+    case gen_tcp:listen(Port, [binary, {reuseaddr, true}, {active, false}, {ip, {127, 0, 0, 1}}]) of
+        {ok, Blocker} ->
+            try
+                Fun()
+            after
+                ok = gen_tcp:close(Blocker)
+            end;
+        {error, eaddrinuse} ->
+            %% The port is already occupied by another process; this is enough for this test.
+            Fun();
+        {error, Reason} ->
+            error({failed_to_prepare_port_blocker, Port, Reason})
+    end.
+
+with_env(Overrides, Fun) ->
+    Saved = save_env(maps:keys(Overrides)),
+    try
+        maps:foreach(
+            fun(Key, Value) ->
+                ok = application:set_env(?APP, Key, Value)
+            end,
+            Overrides
+        ),
+        Fun()
+    after
+        restore_env(Saved)
+    end.
+
+save_env(Keys) ->
+    maps:from_list([{Key, application:get_env(?APP, Key)} || Key <- Keys]).
+
+restore_env(Saved) ->
+    maps:foreach(
+        fun
+            (Key, undefined) ->
+                application:unset_env(?APP, Key);
+            (Key, {ok, Value}) ->
+                ok = application:set_env(?APP, Key, Value)
+        end,
+        Saved
+    ).
+
+with_ipv6_support(Fun) ->
+    case gen_tcp:listen(
+        0,
+        [binary, inet6, {reuseaddr, true}, {active, false}, {ip, {0, 0, 0, 0, 0, 0, 0, 1}}]
+    ) of
+        {ok, Probe} ->
+            ok = gen_tcp:close(Probe),
+            Fun();
+        {error, eafnosupport} ->
+            ok;
+        {error, einval} ->
+            ok;
+        {error, Reason} ->
+            error({unexpected_ipv6_probe_error, Reason})
+    end.

--- a/test/remote_SUITE.erl
+++ b/test/remote_SUITE.erl
@@ -286,7 +286,7 @@ call_unreachable_peer(_Config) ->
             Mref = monitor(process, Pid),
             receive
                 {'DOWN', Mref, process, Pid, _Reason} ->
-                    ?assertEqual(undefined, gen_rpc_client:where_is(UnreachableNode)),
+                    ?retry(20, 50, ?assertEqual(undefined, gen_rpc_client:where_is(UnreachableNode))),
                     ok
             after
                 5000 ->


### PR DESCRIPTION
## Summary
- Add `gen_rpc:check_server_ports_available/0`
- Implement server listen port availability probing in `gen_rpc_helper`
- Fixed a test race condition, previously, the invalid_cookie case may not be able to observe auth failure reason because the client process might have already shutdown when making the gen_server call. Now the auth failure log is converted to a trace point, so it can be asserted from the tests.

## Validation
- `rebar3 eunit --module=gen_rpc_port_check_tests`
