### PR TITLE
feat: accept extra_process_flags option

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,12 @@ and pass them as the node list in the multi-node function.
 
 - `acceptor_socket_active_n`: Integer (default = 100) for RPC acceptor flow control.
 
+- `extra_process_flags`: A list of `{Flag, Value}` tuples applied via `erlang:process_flag/2` to each client and acceptor process on startup. Defaults to `[]`. Example:
+
+    ```erlang
+    {extra_process_flags, [{fullsweep_after, 20}]}
+    ```
+
 - `logger`: A module which exports `log/4` API for RPC client events: `log(Level, Type, Msg, Data)` where:
   - `Level`: is the log level, `debug`, `info`, `error`, etc
   - `Type`: The type of message, possible values are: `client_init`, `client_send`, ... TODO

--- a/src/gen_rpc.app.src
+++ b/src/gen_rpc.app.src
@@ -95,7 +95,10 @@
         %% 0 means no compression, 9 max compression level
         {compress, 0},
         %% Threshold for compression to kick in
-        {compression_threshold, 1024}
+        {compression_threshold, 1024},
+        %% Extra process flags applied to client and acceptor processes.
+        %% Example: [{fullsweep_after, 20}]
+        {extra_process_flags, []}
     ]},
     {modules, []}]
 }.

--- a/src/gen_rpc_acceptor.erl
+++ b/src/gen_rpc_acceptor.erl
@@ -73,6 +73,7 @@ set_socket(Pid, Socket) when is_pid(Pid) ->
 %%% ===================================================
 init({Driver, Peer}) ->
     ok = gen_rpc_helper:set_optimal_process_flags(),
+    ok = gen_rpc_helper:set_extra_process_flags(),
     {Control, ControlList} = gen_rpc_helper:get_rpc_module_control(),
     {DriverMod, _DriverPort, DriverClosed, DriverError} = gen_rpc_helper:get_server_driver_options(Driver),
     {ok, waiting_for_socket, #state{driver=Driver,

--- a/src/gen_rpc_client.erl
+++ b/src/gen_rpc_client.erl
@@ -248,6 +248,7 @@ init({NodeOrTuple}) ->
                           NodeOrTuple
                   end,
     ok = gen_rpc_helper:set_optimal_process_flags(),
+    ok = gen_rpc_helper:set_extra_process_flags(),
     case gen_rpc_helper:get_client_config_per_node(Node) of
         {error, Reason} ->
             ?log(error, "external_source_error",

--- a/src/gen_rpc_helper.erl
+++ b/src/gen_rpc_helper.erl
@@ -27,6 +27,7 @@
          socket_to_string/1,
          host_from_node/1,
          set_optimal_process_flags/0,
+         set_extra_process_flags/0,
          is_driver_enabled/1,
          merge_sockopt_lists/2,
          get_user_tcp_opts/1,
@@ -92,6 +93,12 @@ set_optimal_process_flags() ->
     _ = erlang:process_flag(trap_exit, true),
     _ = erlang:process_flag(priority, high),
     _ = erlang:process_flag(message_queue_data, off_heap),
+    ok.
+
+-spec set_extra_process_flags() -> ok.
+set_extra_process_flags() ->
+    Flags = application:get_env(?APP, extra_process_flags, []),
+    lists:foreach(fun({Flag, Value}) -> _ = erlang:process_flag(Flag, Value) end, Flags),
     ok.
 
 %% Merge lists that contain both tuples and simple values observing

--- a/test/gen_rpc_helper_tests.erl
+++ b/test/gen_rpc_helper_tests.erl
@@ -1,0 +1,50 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2026 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+
+-module(gen_rpc_helper_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-define(APP, gen_rpc).
+
+set_extra_process_flags_empty_test() ->
+    with_env(#{extra_process_flags => []}, fun() ->
+        ?assertEqual(ok, gen_rpc_helper:set_extra_process_flags())
+    end).
+
+set_extra_process_flags_multiple_test() ->
+    with_env(#{extra_process_flags => [{fullsweep_after, 10}, {message_queue_data, on_heap}]}, fun() ->
+        ok = gen_rpc_helper:set_extra_process_flags(),
+        ?assertMatch({fullsweep_after, 10}, erlang:process_info(self(), fullsweep_after)),
+        ?assertMatch({message_queue_data, on_heap}, erlang:process_info(self(), message_queue_data))
+    end).
+
+set_extra_process_flags_not_configured_test() ->
+    Saved = application:get_env(?APP, extra_process_flags),
+    try
+        application:unset_env(?APP, extra_process_flags),
+        ?assertEqual(ok, gen_rpc_helper:set_extra_process_flags())
+    after
+        case Saved of
+            undefined -> application:unset_env(?APP, extra_process_flags);
+            {ok, V}   -> application:set_env(?APP, extra_process_flags, V)
+        end
+    end.
+
+%%% Helpers
+
+with_env(Overrides, Fun) ->
+    Saved = #{ Key => application:get_env(?APP, Key) || Key <- maps:keys(Overrides) },
+    try
+        maps:foreach(fun(Key, Value) -> ok = application:set_env(?APP, Key, Value) end, Overrides),
+        Fun()
+    after
+        maps:foreach(
+            fun
+                (Key, undefined) -> application:unset_env(?APP, Key);
+                (Key, {ok, Value}) -> ok = application:set_env(?APP, Key, Value)
+            end,
+            Saved
+        )
+    end.


### PR DESCRIPTION
A list of {Flag, Value} tuples applied via `erlang:process_flag/2` to each client and acceptor process on startup.

Using `fullsweep_after=20` has been helpful for us to keep the `gen_rpc` acceptor and `client` processes from using too much memory as they can receive a lot of messages that can be discarded straightaway after processing and can be quickly garbage collected.

From the [Erlang docs](https://www.erlang.org/docs/26/man/erlang#spawn_opt-4):

> A few cases when it can be useful to change fullsweep_after:
>
>    * If binaries that are no longer used are to be thrown away as soon as possible. (Set Number to zero.)
>    * A process that mostly have short-lived data is fullsweeped seldom or never, that is, the old heap contains mostly garbage. To ensure a fullsweep occasionally, set Number to a suitable value, such as 10 or 20.
>    * In embedded systems with a limited amount of RAM and no virtual memory, you might want to preserve memory by setting Number to zero. (The value can be set globally, see erlang:system_flag/2.)